### PR TITLE
Flame fix patch

### DIFF
--- a/balatro-mobile-maker/View.cs
+++ b/balatro-mobile-maker/View.cs
@@ -484,6 +484,11 @@ existing_zip.close()");
         //On-screen keyboard
         ApplyPatch("functions/button_callbacks.lua", "G.CONTROLLER.text_input_hook == e and G.CONTROLLER.HID.controller", "  if G.CONTROLLER.text_input_hook == e and (G.CONTROLLER.HID.controller or G.CONTROLLER.HID.touch) then");
 
+        // Flame fix patch
+        ApplyPatch("resources/shaders/flame.fs", "#define MY_HIGHP_OR_MEDIUMP highp", "\t#define MY_HIGHP_OR_MEDIUMP highp\n\tprecision highp float;");
+        ApplyPatch("resources/shaders/flame.fs", "#define MY_HIGHP_OR_MEDIUMP mediump", "\t#define MY_HIGHP_OR_MEDIUMP mediump\n\tprecision mediump float;");
+        ApplyPatch("resources/shaders/flame.fs", "vec4 effect( vec4 colour, Image texture, vec2 texture_coords, vec2 screen_coords )", "mediump vec4 effect( mediump vec4 colour, Image texture, mediump vec2 texture_coords, mediump vec2 screen_coords )");
+
         //Ask whether they want the FPS cap patch
         if (AskQuestion("Would you like to apply the FPS cap patch?"))
         {


### PR DESCRIPTION
Always use high precision if possible, otherwise use mediump.

Also forces mediump precision on the "effect" function's parameters so Love2D doesn't explode when using highp.