### PR TITLE
added OSX save transfer support + OSX adb + standalone shell scripts

### DIFF
--- a/balatro-mobile-maker/Constants.cs
+++ b/balatro-mobile-maker/Constants.cs
@@ -15,6 +15,7 @@ internal static class Constants
 
     //ADB
     public const string PlatformToolsLink = "https://dl.google.com/android/repository/platform-tools-latest-windows.zip";
+    public const string PlatformToolsLinkOSX = "https://dl.google.com/android/repository/platform-tools-latest-darwin.zip";
 
     //OpenJDK Download Links
     //TODO: Find JDK links for all platforms
@@ -29,7 +30,7 @@ internal static class Constants
     public const string OpenJDKOSXX64Link = "https://aka.ms/download-jdk/microsoft-jdk-21.0.3-macos-x64.tar.gz";
     public const string OpenJDKOSXArm64Link = "https://aka.ms/download-jdk/microsoft-jdk-21.0.3-macos-aarch64.tar.gz";
 
-    
+
     //7-Zip Download links
     //Win
     public const string SevenzipWinX64Link = "https://github.com/blake502/balatro-mobile-maker/releases/download/Additional-Tools-1.1/7za-x64.exe";
@@ -44,4 +45,4 @@ internal static class Constants
     public const string SevenzipOSXLink = "https://www.7-zip.org/a/7z2403-mac.tar.xz";
 
 
-} 
+}

--- a/balatro-mobile-maker/Platform.cs
+++ b/balatro-mobile-maker/Platform.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 //using System.IO;
 using static balatro_mobile_maker.View;
 using static balatro_mobile_maker.Tools;
+using System.IO;
 
 namespace balatro_mobile_maker;
 
@@ -15,8 +16,8 @@ internal class Platform
 {
     //I'm not sure which way will be easier to work with, so I'm doing both.
     public static bool isWindows = System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-    private static bool isOSX = System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
-    private static bool isLinux = System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+    public static bool isOSX = System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+    public static bool isLinux = System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
 
     private static bool isX64 = System.Runtime.InteropServices.RuntimeInformation.OSArchitecture == Architecture.X64;
     private static bool isX86 = System.Runtime.InteropServices.RuntimeInformation.OSArchitecture == Architecture.X86;
@@ -29,10 +30,10 @@ internal class Platform
         if (isWindows)
             RunCommand("platform-tools\\platform-tools\\adb.exe", args);
 
+        if (isOSX)
+            RunCommand("platform-tools\\platform-tools\\adb", args);
 
-        //TODO: Implement ADB for OSX and Linux
-        if (isOSX) { /*...*/ }
-
+        //TODO: Implement ADB for Linux
         if (isLinux) { /*...*/ }
     }
 
@@ -197,7 +198,7 @@ internal class Platform
 
         //TODO: Implement
         if (isOSX)
-           return Environment.GetFolderPath(Environment.SpecialFolder.UserProfile) + "/Library/Application Support/Balatro";
+            return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Application Support", "Balatro");
 
         return ".";
     }
@@ -207,7 +208,7 @@ internal class Platform
     //If it does already exist, this returns true
     public static bool gameExists()
     {
-        if(isWindows)
+        if (isWindows)
             return fileExists("Balatro.exe");
 
 

--- a/osx-pull-android-saves.sh
+++ b/osx-pull-android-saves.sh
@@ -1,0 +1,22 @@
+# Standalone shell script for OSX
+# Pulls saves from android device to local disk
+rm -r ./BalatroTMP
+mkdir ./BalatroTMP/
+mkdir ./BalatroTMP/files/
+touch ./BalatroTMP/files/settings.jkr
+adb shell run-as com.unofficial.balatro cat files/save/game/settings.jkr > ./BalatroTMP/files/settings.jkr
+
+for i in {1..3}; do
+  mkdir ./BalatroTMP/files/$i/
+  # touch ./BalatroTMP/files/$i/profile.jkr
+  adb shell run-as com.unofficial.balatro cat files/save/game/$i/profile.jkr > ./BalatroTMP/files/$i/profile.jkr
+  # touch ./BalatroTMP/files/$i/meta.jkr
+  adb shell run-as com.unofficial.balatro cat files/save/game/$i/meta.jkr > ./BalatroTMP/files/$i/meta.jkr
+  # touch ./BalatroTMP/files/$i/save.jkr
+  adb shell run-as com.unofficial.balatro cat files/save/game/$i/save.jkr > ./BalatroTMP/files/$i/save.jkr
+done
+
+find ./BalatroTMP/files/ -maxdepth 2 -size 0c | xargs rm
+find ./BalatroTMP/files/ -type d -empty -delete
+cp -r ./BalatroTMP/files/. ~/Library/Application\ Support/Balatro
+rm -r ./BalatroTMP

--- a/osx-push-steam-saves.sh
+++ b/osx-push-steam-saves.sh
@@ -1,0 +1,13 @@
+# Standalone shell script for OSX
+# Pushes steam saves to android device
+
+adb shell rm -r /data/local/tmp/balatro
+adb shell mkdir /data/local/tmp/balatro
+adb shell mkdir /data/local/tmp/balatro/files
+adb shell mkdir /data/local/tmp/balatro/files/save
+adb shell mkdir /data/local/tmp/balatro/files/save/game
+
+adb push ~/Library/Application\ Support/Balatro /data/local/tmp/balatro/files/save/game
+adb shell am force-stop com.unofficial.balatro
+adb shell run-as com.unofficial.balatro cp -r /data/local/tmp/balatro/files .
+adb shell rm -r /data/local/tmp/balatro


### PR DESCRIPTION
I've hacked together OSX save transfer support, seems to work fine for me.

I also found it a little annoying to run the whole tool every time just to transfer saves, so I added two shell scripts that can be run from terminal simply with `sh ./osx-push-steam-saves.sh` or `sh ./osx-pull-android-saves.sh`. Might be nice to do the same for windows users one day or improve the tool so you can shortcut to that part quickly.

Full changes:
1. ADB support for OSX
3. Disable BACKUP for OSX - xcopy isn't working, maybe I'm missing something simple
4. Save transfers to and from android/steam works within tool
5. Slight readability/code duplication refactor for profile saves